### PR TITLE
Added Diffie Hellman Group 14 Key Exchange

### DIFF
--- a/lib/Net/SSH/Perl.pm
+++ b/lib/Net/SSH/Perl.pm
@@ -26,7 +26,7 @@ eval {
     $HOSTNAME = hostname();
 };
 
-$VERSION = '1.36';
+$VERSION = '1.37';
 
 sub VERSION { $VERSION }
 
@@ -591,6 +591,15 @@ the client finds one that authenticates successfully.
 If you don't provide this, RSA authentication defaults to using
 F<$ENV{HOME}/.ssh/identity>, and DSA authentication defaults to
 F<$ENV{HOME}/.ssh/id_dsa>.
+
+=item * strict_host_key_checking
+
+This corresponds to the I<StrictHostKeyChecking> ssh configuration
+option. Allowed values are I<no>, I<yes>, or I<ask>. I<no> disables
+host key checking, e.g., if you connect to a virtual host that answers
+to multiple IP addresses. I<yes> or I<ask> enable it, and when it
+fails in I<interactive> mode, you are asked whether to continue. The
+host is then added to the list of known hosts.
 
 =item * compression
 

--- a/lib/Net/SSH/Perl/Config.pm
+++ b/lib/Net/SSH/Perl/Config.pm
@@ -30,6 +30,7 @@ use Carp qw( croak );
     RhostsAuthentication    => [ \&_set_yesno, 'auth_rhosts' ],
     RhostsRSAAuthentication => [ \&_set_yesno, 'auth_rhosts_rsa' ],
     RSAAuthentication       => [ \&_set_yesno, 'auth_rsa' ],
+    StrictHostKeyChecking   => [ \&_set_str, 'strict_host_key_checking' ],
     UsePrivilegedPort       => [ \&_set_yesno, 'privileged' ],
     User                    => [ \&_set_str, 'user' ],
     UserKnownHostsFile      => [ \&_set_str, 'user_known_hosts' ],

--- a/lib/Net/SSH/Perl/Constants.pm
+++ b/lib/Net/SSH/Perl/Constants.pm
@@ -111,7 +111,8 @@ use vars qw( %CONSTANTS );
     'CHAN_CLOSE_RCVD' => 0x02,
 
     'KEX_DH1' => 'diffie-hellman-group1-sha1',
-    'KEX_DEFAULT_KEX' => 'diffie-hellman-group1-sha1',
+    'KEX_DH14' => 'diffie-hellman-group14-sha1',
+    'KEX_DEFAULT_KEX' => 'diffie-hellman-group1-sha1,diffie-hellman-group14-sha1',
     'KEX_DEFAULT_PK_ALG' => 'ssh-dss,ssh-rsa',
     'KEX_DEFAULT_ENCRYPT' => '3des-cbc,blowfish-cbc,arcfour',
     'KEX_DEFAULT_MAC' => 'hmac-sha1,hmac-md5',

--- a/lib/Net/SSH/Perl/Kex.pm
+++ b/lib/Net/SSH/Perl/Kex.pm
@@ -4,6 +4,7 @@ package Net::SSH::Perl::Kex;
 use strict;
 
 use Net::SSH::Perl::Kex::DH1;
+use Net::SSH::Perl::Kex::DH14;
 use Net::SSH::Perl::Cipher;
 use Net::SSH::Perl::Mac;
 use Net::SSH::Perl::Comp;
@@ -138,12 +139,12 @@ sub exchange_kexinit {
     $packet->send;
 
     if ( defined $received_packet ) {
-	$ssh->debug("Received key-exchange init (KEXINIT), sent response.");
-	$packet = $received_packet;
+        $ssh->debug("Received key-exchange init (KEXINIT), sent response.");
+        $packet = $received_packet;
     }
     else {
-	$ssh->debug("Sent key-exchange init (KEXINIT), wait response.");
-	$packet = Net::SSH::Perl::Packet->read_expect($ssh, SSH2_MSG_KEXINIT);
+        $ssh->debug("Sent key-exchange init (KEXINIT), wait response.");
+        $packet = Net::SSH::Perl::Packet->read_expect($ssh, SSH2_MSG_KEXINIT);
     }
     $kex->{server_kexinit} = $packet->data;
 
@@ -161,7 +162,7 @@ sub derive_keys {
     my @keys;
     for my $i (0..5) {
         push @keys, derive_key(ord('A')+$i, $kex->{we_need}, $hash,
-			       $shared_secret, $session_id);
+                   $shared_secret, $session_id);
     }
     my $is_ssh2 = $kex->{ssh}->protocol == PROTOCOL_SSH2;
     for my $mode (0, 1) {
@@ -219,6 +220,9 @@ sub choose_kex {
     $kex->{algorithm} = $name;
     if ($name eq KEX_DH1) {
         $kex->{class_name} = __PACKAGE__ . "::DH1";
+    }
+    elsif ($name eq KEX_DH14) {
+        $kex->{class_name} = __PACKAGE__ . "::DH14";
     }
     else {
         croak "Bad kex algorithm $name";

--- a/lib/Net/SSH/Perl/Kex/DH.pm
+++ b/lib/Net/SSH/Perl/Kex/DH.pm
@@ -1,0 +1,164 @@
+# $Id: DH.pm,v 1.19 2009/01/26 01:00:25 turnstep Exp $
+
+package Net::SSH::Perl::Kex::DH;
+use strict;
+
+use Net::SSH::Perl::Buffer;
+use Net::SSH::Perl::Packet;
+use Net::SSH::Perl::Constants qw( :msg2 :kex );
+use Net::SSH::Perl::Key;
+use Net::SSH::Perl::Util qw( bitsize );
+
+use Carp qw( croak );
+use Crypt::DH;
+use Math::Pari;
+use Digest::SHA1 qw( sha1 );
+use Scalar::Util qw(weaken);
+
+use Net::SSH::Perl::Kex;
+use base qw( Net::SSH::Perl::Kex );
+
+sub new {
+    my $class = shift;
+    my $ssh = shift;
+    my $kex = bless { ssh => $ssh }, $class;
+    weaken $kex->{ssh};
+    $kex;
+}
+
+sub exchange {
+    my $kex = shift;
+    my $ssh = $kex->{ssh};
+    my $packet;
+    my $dh = $kex->_dh_new_group;
+
+    $ssh->debug("Entering Diffie-Hellman Group 1 key exchange.");
+    $packet = $ssh->packet_start(SSH2_MSG_KEXDH_INIT);
+    $packet->put_mp_int($dh->pub_key);
+    $packet->send;
+
+    $ssh->debug("Sent DH public key, waiting for reply.");
+    $packet = Net::SSH::Perl::Packet->read_expect($ssh,
+        SSH2_MSG_KEXDH_REPLY);
+
+    my $host_key_blob = $packet->get_str;
+    my $s_host_key = Net::SSH::Perl::Key->new_from_blob($host_key_blob,
+        \$ssh->{datafellows});
+    $ssh->debug("Received host key, type '" . $s_host_key->ssh_name . "'.");
+
+    $ssh->check_host_key($s_host_key);
+
+    my $dh_server_pub = $packet->get_mp_int;
+    my $signature = $packet->get_str;
+
+    $ssh->fatal_disconnect("Bad server public DH value")
+        unless _pub_is_valid($dh, $dh_server_pub);
+
+    $ssh->debug("Computing shared secret key.");
+    my $shared_secret = $dh->compute_key($dh_server_pub);
+
+    my $hash = $kex->kex_hash(
+        $ssh->client_version_string,
+        $ssh->server_version_string,
+        $kex->client_kexinit,
+        $kex->server_kexinit,
+        $host_key_blob,
+        $dh->pub_key,
+        $dh_server_pub,
+        $shared_secret);
+
+    $ssh->debug("Verifying server signature.");
+    croak "Key verification failed for server host key"
+        unless $s_host_key->verify($signature, $hash);
+
+    $ssh->session_id($hash);
+
+    $kex->derive_keys($hash, $shared_secret, $ssh->session_id);
+}
+
+sub kex_hash {
+    my $kex = shift;
+    my($c_vs, $s_vs, $c_kexinit, $s_kexinit, $s_host_key_blob,
+       $c_dh_pub, $s_dh_pub, $shared_secret) = @_;
+    my $b = Net::SSH::Perl::Buffer->new( MP => 'SSH2' );
+    $b->put_str($c_vs);
+    $b->put_str($s_vs);
+
+    $b->put_int32($c_kexinit->length + 1);
+    $b->put_int8(SSH2_MSG_KEXINIT);
+    $b->put_chars($c_kexinit->bytes);
+    $b->put_int32($s_kexinit->length + 1);
+    $b->put_int8(SSH2_MSG_KEXINIT);
+    $b->put_chars($s_kexinit->bytes);
+
+    $b->put_str($s_host_key_blob);
+    $b->put_mp_int($c_dh_pub);
+    $b->put_mp_int($s_dh_pub);
+    $b->put_mp_int($shared_secret);
+
+    sha1($b->bytes);
+}
+
+sub _pub_is_valid {
+    my($dh, $dh_pub) = @_;
+    return if $dh_pub < 0;
+
+    my $bits_set = 0;
+    my $n = bitsize($dh_pub);
+    for my $i (0..$n) {
+	$bits_set++ if $dh_pub & (PARI(1) << PARI($i));
+        last if $bits_set > 1;
+    }
+
+    $bits_set > 1 && $dh_pub < $dh->p;
+}
+
+sub _gen_key {
+	my $key = shift;
+    my $dh = shift;
+    my $tries = 0;
+    {
+	$dh->generate_keys;
+	last if _pub_is_valid($dh, $dh->pub_key);
+	croak "Too many bad keys: giving up" if $tries++ > 10;
+    }
+}
+
+1;
+__END__
+
+=head1 NAME
+
+Net::SSH::Perl::Kex::DH - Diffie-Hellman Group Agnostic Key Exchange
+
+=head1 SYNOPSIS
+	
+	# This class should not be used directly, but rather as a base for DH1, DH14, etc 
+
+    use Net::SSH::Perl::Kex::DH;
+	use base qw( Net::SSH::Perl::Kex::DH );
+
+	# Simply implement _dh_new_group and return the Crypt::DH group
+	sub _dh_new_group {
+		my $kex = shift;
+		...
+		$dh;
+	}
+
+=head1 DESCRIPTION
+
+I<Net::SSH::Perl::Kex::DH> implements Diffie-Hellman Group Agnostic
+Exchange for I<Net::SSH::Perl>. It is a subclass of
+I<Net::SSH::Perl::Kex>.
+
+Key Exchange uses the Diffie-Hellman key exchange algorithm
+to produce a shared secret key between client and server, without
+ever sending the shared secret over the insecure network. All that is
+sent are the client and server public keys.
+
+=head1 AUTHOR & COPYRIGHTS
+
+Please see the Net::SSH::Perl manpage for author, copyright, and
+license information.
+
+=cut

--- a/lib/Net/SSH/Perl/Kex/DH1.pm
+++ b/lib/Net/SSH/Perl/Kex/DH1.pm
@@ -3,132 +3,19 @@
 package Net::SSH::Perl::Kex::DH1;
 use strict;
 
-use Net::SSH::Perl::Buffer;
-use Net::SSH::Perl::Packet;
-use Net::SSH::Perl::Constants qw( :msg2 :kex );
-use Net::SSH::Perl::Key;
-use Net::SSH::Perl::Util qw( bitsize );
-
 use Carp qw( croak );
 use Crypt::DH;
-use Math::Pari;
-use Digest::SHA1 qw( sha1 );
-use Scalar::Util qw(weaken);
 
-use Net::SSH::Perl::Kex;
-use base qw( Net::SSH::Perl::Kex );
+use Net::SSH::Perl::Kex::DH;
+use base qw( Net::SSH::Perl::Kex::DH );
 
-sub new {
-    my $class = shift;
-    my $ssh = shift;
-    my $kex = bless { ssh => $ssh }, $class;
-    weaken $kex->{ssh};
-    $kex;
-}
-
-sub exchange {
-    my $kex = shift;
-    my $ssh = $kex->{ssh};
-    my $packet;
-    my $dh = _dh_new_group1();
-
-    $ssh->debug("Entering Diffie-Hellman Group 1 key exchange.");
-    $packet = $ssh->packet_start(SSH2_MSG_KEXDH_INIT);
-    $packet->put_mp_int($dh->pub_key);
-    $packet->send;
-
-    $ssh->debug("Sent DH public key, waiting for reply.");
-    $packet = Net::SSH::Perl::Packet->read_expect($ssh,
-        SSH2_MSG_KEXDH_REPLY);
-
-    my $host_key_blob = $packet->get_str;
-    my $s_host_key = Net::SSH::Perl::Key->new_from_blob($host_key_blob,
-        \$ssh->{datafellows});
-    $ssh->debug("Received host key, type '" . $s_host_key->ssh_name . "'.");
-
-    $ssh->check_host_key($s_host_key);
-
-    my $dh_server_pub = $packet->get_mp_int;
-    my $signature = $packet->get_str;
-
-    $ssh->fatal_disconnect("Bad server public DH value")
-        unless _pub_is_valid($dh, $dh_server_pub);
-
-    $ssh->debug("Computing shared secret key.");
-    my $shared_secret = $dh->compute_key($dh_server_pub);
-
-    my $hash = $kex->kex_hash(
-        $ssh->client_version_string,
-        $ssh->server_version_string,
-        $kex->client_kexinit,
-        $kex->server_kexinit,
-        $host_key_blob,
-        $dh->pub_key,
-        $dh_server_pub,
-        $shared_secret);
-
-    $ssh->debug("Verifying server signature.");
-    croak "Key verification failed for server host key"
-        unless $s_host_key->verify($signature, $hash);
-
-    $ssh->session_id($hash);
-
-    $kex->derive_keys($hash, $shared_secret, $ssh->session_id);
-}
-
-sub kex_hash {
-    my $kex = shift;
-    my($c_vs, $s_vs, $c_kexinit, $s_kexinit, $s_host_key_blob,
-       $c_dh_pub, $s_dh_pub, $shared_secret) = @_;
-    my $b = Net::SSH::Perl::Buffer->new( MP => 'SSH2' );
-    $b->put_str($c_vs);
-    $b->put_str($s_vs);
-
-    $b->put_int32($c_kexinit->length + 1);
-    $b->put_int8(SSH2_MSG_KEXINIT);
-    $b->put_chars($c_kexinit->bytes);
-    $b->put_int32($s_kexinit->length + 1);
-    $b->put_int8(SSH2_MSG_KEXINIT);
-    $b->put_chars($s_kexinit->bytes);
-
-    $b->put_str($s_host_key_blob);
-    $b->put_mp_int($c_dh_pub);
-    $b->put_mp_int($s_dh_pub);
-    $b->put_mp_int($shared_secret);
-
-    sha1($b->bytes);
-}
-
-sub _dh_new_group1 {
+sub _dh_new_group {
+	my $kex = shift;
     my $dh = Crypt::DH->new;
     $dh->g(2);
     $dh->p("0xFFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020BBEA63B139B22514A08798E3404DDEF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7EDEE386BFB5A899FA5AE9F24117C4B1FE649286651ECE65381FFFFFFFFFFFFFFFF");
-    _gen_key($dh);
+    $kex->_gen_key($dh);
     $dh;
-}
-
-sub _pub_is_valid {
-    my($dh, $dh_pub) = @_;
-    return if $dh_pub < 0;
-
-    my $bits_set = 0;
-    my $n = bitsize($dh_pub);
-    for my $i (0..$n) {
-	$bits_set++ if $dh_pub & (PARI(1) << PARI($i));
-        last if $bits_set > 1;
-    }
-
-    $bits_set > 1 && $dh_pub < $dh->p;
-}
-
-sub _gen_key {
-    my $dh = shift;
-    my $tries = 0;
-    {
-	$dh->generate_keys;
-	last if _pub_is_valid($dh, $dh->pub_key);
-	croak "Too many bad keys: giving up" if $tries++ > 10;
-    }
 }
 
 1;

--- a/lib/Net/SSH/Perl/Kex/DH14.pm
+++ b/lib/Net/SSH/Perl/Kex/DH14.pm
@@ -1,0 +1,70 @@
+# $Id: DH14.pm,v 1.19 2009/01/26 01:00:25 turnstep Exp $
+
+package Net::SSH::Perl::Kex::DH14;
+use strict;
+
+use Carp qw( croak );
+use Crypt::DH;
+
+use Net::SSH::Perl::Kex::DH;
+use base qw( Net::SSH::Perl::Kex::DH );
+
+sub _dh_new_group {
+	my $kex = shift;
+	my $dh = Crypt::DH->new;
+	$dh->g(2);
+	$dh->p("0xFFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020BBEA63B139B22514A08798E3404DDEF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7EDEE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3DC2007CB8A163BF0598DA48361C55D39A69163FA8FD24CF5F83655D23DCA3AD961C62F356208552BB9ED529077096966D670C354E4ABC9804F1746C08CA18217C32905E462E36CE3BE39E772C180E86039B2783A2EC07A28FB5C55DF06F4C52C9DE2BCBF6955817183995497CEA956AE515D2261898FA051015728E5A8AACAA68FFFFFFFFFFFFFFFF");
+	$kex->_gen_key($dh);
+	$dh;
+}
+
+1;
+__END__
+
+=head1 NAME
+
+Net::SSH::Perl::Kex::DH14 - Diffie-Hellman Group 14 Key Exchange
+
+=head1 SYNOPSIS
+
+    use Net::SSH::Perl::Kex;
+    my $kex = Net::SSH::Perl::Kex->new;
+    my $dh14 = bless $kex, 'Net::SSH::Perl::Kex::DH14';
+
+    $dh14->exchange;
+
+=head1 DESCRIPTION
+
+I<Net::SSH::Perl::Kex::DH14> implements Diffie-Hellman Group 14 Key
+Exchange for I<Net::SSH::Perl>. It is a subclass of
+I<Net::SSH::Perl::Kex>.
+
+Group 14 Key Exchange uses the Diffie-Hellman key exchange algorithm
+to produce a shared secret key between client and server, without
+ever sending the shared secret over the insecure network. All that is
+sent are the client and server public keys.
+
+I<Net::SSH::Perl::Kex::DH14> uses I<Crypt::DH> for the Diffie-Hellman
+implementation. The I<p> value is set to
+
+      FFFFFFFF FFFFFFFF C90FDAA2 2168C234 C4C6628B 80DC1CD1
+      29024E08 8A67CC74 020BBEA6 3B139B22 514A0879 8E3404DD
+      EF9519B3 CD3A431B 302B0A6D F25F1437 4FE1356D 6D51C245
+      E485B576 625E7EC6 F44C42E9 A637ED6B 0BFF5CB6 F406B7ED
+      EE386BFB 5A899FA5 AE9F2411 7C4B1FE6 49286651 ECE45B3D
+      C2007CB8 A163BF05 98DA4836 1C55D39A 69163FA8 FD24CF5F
+      83655D23 DCA3AD96 1C62F356 208552BB 9ED52907 7096966D
+      670C354E 4ABC9804 F1746C08 CA18217C 32905E46 2E36CE3B
+      E39E772C 180E8603 9B2783A2 EC07A28F B5C55DF0 6F4C52C9
+      DE2BCBF6 95581718 3995497C EA956AE5 15D22618 98FA0510
+      15728E5A 8AACAA68 FFFFFFFF FFFFFFFF
+
+Which is taken from the libssh2 source code.
+And the generator I<g> is set to I<2>.
+
+=head1 AUTHOR & COPYRIGHTS
+
+Please see the Net::SSH::Perl manpage for author, copyright, and
+license information.
+
+=cut


### PR DESCRIPTION
Added support for SSH2 servers that don't support DH1.
Separated out generic DH code from DH1.pm to DH.pm and added
DH14 in DH14.pm
This will make adding different Diffie Hellman Groups
possible and easy with DH.pm as the base class.

Also fixed some indentation errors and added
StrictHostKeyChecking from Net::SSH::Perl v1.37 on CPAN
