### PR TITLE
select() issues on Win32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 MYMETA.json
 MYMETA.yml
 Makefile
+Makefile.old
 blib
 pm_to_blib
 Net-SSH-Perl-*

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ blib
 pm_to_blib
 Net-SSH-Perl-*
 Debian_CPANTS.txt
+MANIFEST.bak

--- a/MANIFEST
+++ b/MANIFEST
@@ -37,7 +37,9 @@ lib/Net/SSH/Perl/Handle.pm
 lib/Net/SSH/Perl/Handle/SSH1.pm
 lib/Net/SSH/Perl/Handle/SSH2.pm
 lib/Net/SSH/Perl/Kex.pm
+lib/Net/SSH/Perl/Kex/DH.pm
 lib/Net/SSH/Perl/Kex/DH1.pm
+lib/Net/SSH/Perl/Kex/DH14.pm
 lib/Net/SSH/Perl/Key.pm
 lib/Net/SSH/Perl/Key/DSA.pm
 lib/Net/SSH/Perl/Key/RSA.pm
@@ -58,9 +60,9 @@ lib/Net/SSH/Perl/Util/SSH2MP.pm
 lib/Net/SSH/Perl/Util/Term.pm
 LICENSE
 Makefile.PL
-MANIFEST
+MANIFEST			This list of files
 MANIFEST.SKIP
-META.yml			Module meta-data (added by MakeMaker)
+META.yml
 README
 SIGNATURE
 t/00-signature.t

--- a/MANIFEST
+++ b/MANIFEST
@@ -58,6 +58,7 @@ lib/Net/SSH/Perl/Util/SSH1Misc.pm
 lib/Net/SSH/Perl/Util/SSH1MP.pm
 lib/Net/SSH/Perl/Util/SSH2MP.pm
 lib/Net/SSH/Perl/Util/Term.pm
+lib/Net/SSH/Perl/Util/Win32.pm
 LICENSE
 Makefile.PL
 MANIFEST			This list of files

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,6 +7,7 @@ use ExtUtils::MakeMaker qw(prompt WriteMakefile);
 my %prereq = (
         'Digest::MD5'       => 0,
         'IO::Socket'        => 0,
+        'File::Spec'        => 0,
 );
 
 my %SSH_PREREQ = (

--- a/eg/cmd.pl
+++ b/eg/cmd.pl
@@ -28,7 +28,7 @@ my $ssh = Net::SSH::Perl->new($host || $this_host,
     cipher => Net::SSH::Perl::Cipher::name($c),
     debug => 1);
 
-my $this_user = scalar getpwuid($<);
+my $this_user = $ENV{USERNAME} || scalar getpwuid($<);
 print "Enter your username on that host: [$this_user] ";
 chomp(my $user = <STDIN>);
 

--- a/lib/Net/SSH/Perl.pm
+++ b/lib/Net/SSH/Perl.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Packet;
 use Net::SSH::Perl::Buffer;

--- a/lib/Net/SSH/Perl.pm
+++ b/lib/Net/SSH/Perl.pm
@@ -10,7 +10,6 @@ use Net::SSH::Perl::Config;
 use Net::SSH::Perl::Constants qw( :protocol :compat :hosts );
 use Net::SSH::Perl::Cipher;
 use Net::SSH::Perl::Util qw( :hosts _read_yes_or_no );
-use Data::Dumper;
 
 use Errno qw( EAGAIN EWOULDBLOCK );
 

--- a/lib/Net/SSH/Perl.pm
+++ b/lib/Net/SSH/Perl.pm
@@ -218,7 +218,11 @@ sub _connect {
     $ssh->{session}{sock} = $sock;
     $ssh->_exchange_identification;
 
-    if ($^O ne 'MSWin32') {
+    if ($^O eq 'MSWin32') {
+      my $nonblocking = 1;
+      ioctl $sock, 0x8004667e, \\$nonblocking;
+    }
+    else {
       defined($sock->blocking(0))
           or die "Can't set socket non-blocking: $!";
     }

--- a/lib/Net/SSH/Perl/Agent.pm
+++ b/lib/Net/SSH/Perl/Agent.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Agent;
 use strict;
+use warnings;
 
 use IO::Socket;
 use Carp qw( croak );

--- a/lib/Net/SSH/Perl/Auth.pm
+++ b/lib/Net/SSH/Perl/Auth.pm
@@ -3,6 +3,7 @@
 package Net::SSH::Perl::Auth;
 
 use strict;
+use warnings;
 use Carp qw( croak );
 
 use vars qw( %AUTH %AUTH_REVERSE @AUTH_ORDER %SUPPORTED );

--- a/lib/Net/SSH/Perl/Auth/ChallengeResponse.pm
+++ b/lib/Net/SSH/Perl/Auth/ChallengeResponse.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Auth::ChallengeResponse;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Constants qw(
     SSH_CMSG_AUTH_TIS

--- a/lib/Net/SSH/Perl/Auth/KeyboardInt.pm
+++ b/lib/Net/SSH/Perl/Auth/KeyboardInt.pm
@@ -3,6 +3,7 @@
 package Net::SSH::Perl::Auth::KeyboardInt;
 
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Util qw( _prompt );
 use Net::SSH::Perl::Constants qw(

--- a/lib/Net/SSH/Perl/Auth/Password.pm
+++ b/lib/Net/SSH/Perl/Auth/Password.pm
@@ -3,6 +3,7 @@
 package Net::SSH::Perl::Auth::Password;
 
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Constants qw(
     SSH_CMSG_AUTH_PASSWORD

--- a/lib/Net/SSH/Perl/Auth/PublicKey.pm
+++ b/lib/Net/SSH/Perl/Auth/PublicKey.pm
@@ -3,6 +3,7 @@
 package Net::SSH::Perl::Auth::PublicKey;
 
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Constants qw(
     SSH2_MSG_USERAUTH_REQUEST

--- a/lib/Net/SSH/Perl/Auth/RSA.pm
+++ b/lib/Net/SSH/Perl/Auth/RSA.pm
@@ -3,6 +3,7 @@
 package Net::SSH::Perl::Auth::RSA;
 
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Constants qw(
     SSH_SMSG_FAILURE

--- a/lib/Net/SSH/Perl/Auth/Rhosts.pm
+++ b/lib/Net/SSH/Perl/Auth/Rhosts.pm
@@ -3,6 +3,7 @@
 package Net::SSH::Perl::Auth::Rhosts;
 
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Constants qw(
     SSH_SMSG_FAILURE

--- a/lib/Net/SSH/Perl/Auth/Rhosts_RSA.pm
+++ b/lib/Net/SSH/Perl/Auth/Rhosts_RSA.pm
@@ -3,6 +3,7 @@
 package Net::SSH::Perl::Auth::Rhosts_RSA;
 
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Constants qw(
     SSH_SMSG_FAILURE

--- a/lib/Net/SSH/Perl/Auth/Rhosts_RSA.pm
+++ b/lib/Net/SSH/Perl/Auth/Rhosts_RSA.pm
@@ -18,6 +18,7 @@ use Net::SSH::Perl::Auth;
 use base qw( Net::SSH::Perl::Auth );
 
 use Scalar::Util qw(weaken);
+use File::Spec::Functions qw( catfile );
 
 sub new {
     my $class = shift;
@@ -39,7 +40,10 @@ sub authenticate {
 
     my $private_key;
     eval {
-        $private_key = _load_private_key("/etc/ssh_host_key");
+        my $ssh_host_key = $^O eq 'MSWin32'
+          ? catfile($ENV{WINDIR}, 'ssh_host_key')
+          : '/etc/ssh_host_key';
+        $private_key = _load_private_key($ssh_host_key);
     };
     $ssh->debug("Rhosts with RSA authentication failed: Can't load private host key."),
         return 0 if $@;

--- a/lib/Net/SSH/Perl/AuthMgr.pm
+++ b/lib/Net/SSH/Perl/AuthMgr.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::AuthMgr;
 use strict;
+use warnings;
 
 use Carp qw( croak );
 

--- a/lib/Net/SSH/Perl/Buffer.pm
+++ b/lib/Net/SSH/Perl/Buffer.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Buffer;
 use strict;
+use warnings;
 
 {
     my %MP_MAP = (

--- a/lib/Net/SSH/Perl/Channel.pm
+++ b/lib/Net/SSH/Perl/Channel.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Channel;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Buffer;
 use Net::SSH::Perl::Constants qw( :msg2 :channels );

--- a/lib/Net/SSH/Perl/ChannelMgr.pm
+++ b/lib/Net/SSH/Perl/ChannelMgr.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::ChannelMgr;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Channel;
 use Net::SSH::Perl::Packet;

--- a/lib/Net/SSH/Perl/Cipher.pm
+++ b/lib/Net/SSH/Perl/Cipher.pm
@@ -3,6 +3,7 @@
 package Net::SSH::Perl::Cipher;
 
 use strict;
+use warnings;
 use Carp qw( croak );
 
 use vars qw( %CIPHERS %CIPHERS_SSH2 %CIPH_REVERSE %SUPPORTED );

--- a/lib/Net/SSH/Perl/Cipher/Blowfish.pm
+++ b/lib/Net/SSH/Perl/Cipher/Blowfish.pm
@@ -3,6 +3,7 @@
 package Net::SSH::Perl::Cipher::Blowfish;
 
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Cipher;
 use base qw( Net::SSH::Perl::Cipher );

--- a/lib/Net/SSH/Perl/Cipher/CBC.pm
+++ b/lib/Net/SSH/Perl/Cipher/CBC.pm
@@ -6,6 +6,7 @@
 
 package Net::SSH::Perl::Cipher::CBC;
 use strict;
+use warnings;
 
 sub new {
     my($class, $ciph, $iv) = @_;

--- a/lib/Net/SSH/Perl/Cipher/CFB.pm
+++ b/lib/Net/SSH/Perl/Cipher/CFB.pm
@@ -6,6 +6,7 @@
 
 package Net::SSH::Perl::Cipher::CFB;
 use strict;
+use warnings;
 
 sub new {
     my($class, $ciph, $iv) = @_;

--- a/lib/Net/SSH/Perl/Cipher/DES.pm
+++ b/lib/Net/SSH/Perl/Cipher/DES.pm
@@ -3,6 +3,7 @@
 package Net::SSH::Perl::Cipher::DES;
 
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Cipher;
 use base qw( Net::SSH::Perl::Cipher );

--- a/lib/Net/SSH/Perl/Cipher/DES3.pm
+++ b/lib/Net/SSH/Perl/Cipher/DES3.pm
@@ -3,6 +3,7 @@
 package Net::SSH::Perl::Cipher::DES3;
 
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Cipher;
 use base qw( Net::SSH::Perl::Cipher );

--- a/lib/Net/SSH/Perl/Cipher/IDEA.pm
+++ b/lib/Net/SSH/Perl/Cipher/IDEA.pm
@@ -3,6 +3,7 @@
 package Net::SSH::Perl::Cipher::IDEA;
 
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Cipher;
 use base qw( Net::SSH::Perl::Cipher );

--- a/lib/Net/SSH/Perl/Cipher/RC4.pm
+++ b/lib/Net/SSH/Perl/Cipher/RC4.pm
@@ -3,6 +3,7 @@
 package Net::SSH::Perl::Cipher::RC4;
 
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Cipher;
 use base qw( Net::SSH::Perl::Cipher );

--- a/lib/Net/SSH/Perl/Comp.pm
+++ b/lib/Net/SSH/Perl/Comp.pm
@@ -3,6 +3,7 @@
 package Net::SSH::Perl::Comp;
 
 use strict;
+use warnings;
 use Carp qw( croak );
 
 use vars qw( %COMP );

--- a/lib/Net/SSH/Perl/Comp/Zlib.pm
+++ b/lib/Net/SSH/Perl/Comp/Zlib.pm
@@ -3,6 +3,7 @@
 package Net::SSH::Perl::Comp::Zlib;
 
 use strict;
+use warnings;
 use Carp qw( croak );
 require Compress::Zlib;
 

--- a/lib/Net/SSH/Perl/Config.pm
+++ b/lib/Net/SSH/Perl/Config.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Config;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Constants qw( :protocol );
 use vars qw( %DIRECTIVES $AUTOLOAD );

--- a/lib/Net/SSH/Perl/Constants.pm
+++ b/lib/Net/SSH/Perl/Constants.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Constants;
 use strict;
+use warnings;
 
 use vars qw( %CONSTANTS );
 %CONSTANTS = (

--- a/lib/Net/SSH/Perl/Handle.pm
+++ b/lib/Net/SSH/Perl/Handle.pm
@@ -1,5 +1,6 @@
 package Net::SSH::Perl::Handle;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Buffer qw( SSH2 );
 

--- a/lib/Net/SSH/Perl/Handle/SSH1.pm
+++ b/lib/Net/SSH/Perl/Handle/SSH1.pm
@@ -1,5 +1,6 @@
 package Net::SSH::Perl::Handle::SSH1;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Buffer;
 use Net::SSH::Perl::Constants qw(

--- a/lib/Net/SSH/Perl/Handle/SSH2.pm
+++ b/lib/Net/SSH/Perl/Handle/SSH2.pm
@@ -1,5 +1,6 @@
 package Net::SSH::Perl::Handle::SSH2;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Buffer;
 use Net::SSH::Perl::Constants qw( :channels );

--- a/lib/Net/SSH/Perl/Kex.pm
+++ b/lib/Net/SSH/Perl/Kex.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Kex;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Kex::DH1;
 use Net::SSH::Perl::Kex::DH14;

--- a/lib/Net/SSH/Perl/Kex/DH.pm
+++ b/lib/Net/SSH/Perl/Kex/DH.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Kex::DH;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Buffer;
 use Net::SSH::Perl::Packet;

--- a/lib/Net/SSH/Perl/Kex/DH1.pm
+++ b/lib/Net/SSH/Perl/Kex/DH1.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Kex::DH1;
 use strict;
+use warnings;
 
 use Carp qw( croak );
 use Crypt::DH;

--- a/lib/Net/SSH/Perl/Kex/DH14.pm
+++ b/lib/Net/SSH/Perl/Kex/DH14.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Kex::DH14;
 use strict;
+use warnings;
 
 use Carp qw( croak );
 use Crypt::DH;

--- a/lib/Net/SSH/Perl/Key.pm
+++ b/lib/Net/SSH/Perl/Key.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Key;
 use strict;
+use warnings;
 
 use Digest::MD5 qw( md5 );
 use Net::SSH::Perl::Buffer;

--- a/lib/Net/SSH/Perl/Key/DSA.pm
+++ b/lib/Net/SSH/Perl/Key/DSA.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Key::DSA;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Buffer;
 use Net::SSH::Perl::Constants qw( SSH_COMPAT_BUG_SIGBLOB );

--- a/lib/Net/SSH/Perl/Key/RSA.pm
+++ b/lib/Net/SSH/Perl/Key/RSA.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Key::RSA;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Buffer;
 use Net::SSH::Perl::Constants qw( SSH_COMPAT_BUG_RSASIGMD5 );

--- a/lib/Net/SSH/Perl/Key/RSA1.pm
+++ b/lib/Net/SSH/Perl/Key/RSA1.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Key::RSA1;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Util qw( :ssh1mp :authfile );
 

--- a/lib/Net/SSH/Perl/Mac.pm
+++ b/lib/Net/SSH/Perl/Mac.pm
@@ -3,6 +3,7 @@
 package Net::SSH::Perl::Mac;
 
 use strict;
+use warnings;
 use Carp qw( croak );
 
 use vars qw( %MAC %MAC_REVERSE %SUPPORTED );

--- a/lib/Net/SSH/Perl/Packet.pm
+++ b/lib/Net/SSH/Perl/Packet.pm
@@ -3,6 +3,7 @@
 package Net::SSH::Perl::Packet;
 
 use strict;
+use warnings;
 use Carp qw( croak );
 use IO::Select;
 use POSIX qw( :errno_h );

--- a/lib/Net/SSH/Perl/SSH1.pm
+++ b/lib/Net/SSH/Perl/SSH1.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::SSH1;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Packet;
 use Net::SSH::Perl::Buffer;

--- a/lib/Net/SSH/Perl/SSH1.pm
+++ b/lib/Net/SSH/Perl/SSH1.pm
@@ -19,6 +19,7 @@ use base qw( Net::SSH::Perl );
 
 use Math::GMP;
 use Carp qw( croak );
+use File::Spec::Functions qw( catfile );
 
 sub version_string {
     my $class = shift;
@@ -28,22 +29,27 @@ sub version_string {
 
 sub _proto_init {
     my $ssh = shift;
-    my $home = $ENV{HOME} || $ENV{HOMEPATH} || (getpwuid($>))[7];
-    unless ($ssh->{config}->get('user_known_hosts')) {
+    my $home = $ENV{HOME} || $ENV{USERPROFILE} || (getpwuid($>))[7];
+    my $config = $ssh->{config};
+
+    unless ($config->get('user_known_hosts')) {
         defined $home or croak "Cannot determine home directory, please set the environment variable HOME";
-        $ssh->{config}->set('user_known_hosts', "$home/.ssh/known_hosts");
+        $config->set('user_known_hosts', catfile($home, '.ssh', 'known_hosts'));
     }
-    unless ($ssh->{config}->get('global_known_hosts')) {
-        $ssh->{config}->set('global_known_hosts', "/etc/ssh_known_hosts");
+    unless ($config->get('global_known_hosts')) {
+        my $glob_known_hosts = $^O eq 'MSWin32'
+          ? catfile( $ENV{WINDIR}, 'ssh_known_hosts' )
+          : '/etc/ssh_known_hosts';
+        $config->set('global_known_hosts', $glob_known_hosts );
     }
-    unless (my $if = $ssh->{config}->get('identity_files')) {
+    unless (my $if = $config->get('identity_files')) {
         defined $home or croak "Cannot determine home directory, please set the environment variable HOME";
-        $ssh->{config}->set('identity_files', [ "$home/.ssh/identity" ]);
+        $config->set('identity_files', [ catfile($home, '.ssh', 'identity') ]);
     }
 
     for my $a (qw( password rhosts rhosts_rsa rsa ch_res )) {
-        $ssh->{config}->set("auth_$a", 1)
-            unless defined $ssh->{config}->get("auth_$a");
+        $config->set("auth_$a", 1)
+            unless defined $config->get("auth_$a");
     }
 }
 

--- a/lib/Net/SSH/Perl/SSH1.pm
+++ b/lib/Net/SSH/Perl/SSH1.pm
@@ -28,7 +28,7 @@ sub version_string {
 
 sub _proto_init {
     my $ssh = shift;
-    my $home = $ENV{HOME} || (getpwuid($>))[7];
+    my $home = $ENV{HOME} || $ENV{HOMEPATH} || (getpwuid($>))[7];
     unless ($ssh->{config}->get('user_known_hosts')) {
         defined $home or croak "Cannot determine home directory, please set the environment variable HOME";
         $ssh->{config}->set('user_known_hosts', "$home/.ssh/known_hosts");

--- a/lib/Net/SSH/Perl/SSH2.pm
+++ b/lib/Net/SSH/Perl/SSH2.pm
@@ -37,7 +37,7 @@ sub version_string {
 
 sub _proto_init {
     my $ssh = shift;
-    my $home = $ENV{HOME} || (getpwuid($>))[7];
+    my $home = $ENV{HOME} || $ENV{HOMEPATH} || (getpwuid($>))[7];
     unless ($ssh->{config}->get('user_known_hosts')) {
         defined $home or croak "Cannot determine home directory, please set the environment variable HOME";
         $ssh->{config}->set('user_known_hosts', "$home/.ssh/known_hosts2");

--- a/lib/Net/SSH/Perl/SSH2.pm
+++ b/lib/Net/SSH/Perl/SSH2.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::SSH2;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Kex;
 use Net::SSH::Perl::ChannelMgr;

--- a/lib/Net/SSH/Perl/Subsystem/Client.pm
+++ b/lib/Net/SSH/Perl/Subsystem/Client.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Subsystem::Client;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Constants qw(
     SSH2_MSG_CHANNEL_OPEN_CONFIRMATION

--- a/lib/Net/SSH/Perl/Subsystem/Server.pm
+++ b/lib/Net/SSH/Perl/Subsystem/Server.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Subsystem::Server;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Buffer;
 use Carp qw( croak );

--- a/lib/Net/SSH/Perl/Util.pm
+++ b/lib/Net/SSH/Perl/Util.pm
@@ -25,6 +25,7 @@ use vars qw( %FUNC_TO_MOD %EXPORT_TAGS );
     _prompt                   => 'Term',
     _read_passphrase          => 'Term',
     _read_yes_or_no           => 'Term',
+    _socketpair               => 'Win32',
 );
 
 %EXPORT_TAGS = (
@@ -34,6 +35,7 @@ use vars qw( %FUNC_TO_MOD %EXPORT_TAGS );
     ssh1mp   => [ qw( _compute_session_id _mp_linearize ) ],
     ssh2mp   => [ qw( bitsize bin2mp mp2bin mod_inverse ) ],
     authfile => [ qw( _load_public_key _load_private_key _save_private_key ) ],
+    win32    => [ qw( _socketpair ) ],
     all      => [ keys %FUNC_TO_MOD ],
 );
 

--- a/lib/Net/SSH/Perl/Util.pm
+++ b/lib/Net/SSH/Perl/Util.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Util;
 use strict;
+use warnings;
 
 use vars qw( %FUNC_TO_MOD %EXPORT_TAGS );
 

--- a/lib/Net/SSH/Perl/Util/Authfile.pm
+++ b/lib/Net/SSH/Perl/Util/Authfile.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Util::Authfile;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Buffer;
 use Net::SSH::Perl::Constants qw( PRIVATE_KEY_ID_STRING );

--- a/lib/Net/SSH/Perl/Util/Hosts.pm
+++ b/lib/Net/SSH/Perl/Util/Hosts.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Util::Hosts;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Constants qw( :hosts );
 

--- a/lib/Net/SSH/Perl/Util/RSA.pm
+++ b/lib/Net/SSH/Perl/Util/RSA.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Util::RSA;
 use strict;
+use warnings;
 
 use Net::SSH::Perl::Constants qw( SSH_CMSG_AUTH_RSA_RESPONSE );
 use Net::SSH::Perl::Util qw( :ssh1mp );

--- a/lib/Net/SSH/Perl/Util/SSH1MP.pm
+++ b/lib/Net/SSH/Perl/Util/SSH1MP.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Util::SSH1MP;
 use strict;
+use warnings;
 
 use Digest::MD5 qw( md5 );
 use Math::GMP;

--- a/lib/Net/SSH/Perl/Util/SSH1Misc.pm
+++ b/lib/Net/SSH/Perl/Util/SSH1Misc.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Util::SSH1Misc;
 use strict;
+use warnings;
 
 use String::CRC32;
 

--- a/lib/Net/SSH/Perl/Util/SSH2MP.pm
+++ b/lib/Net/SSH/Perl/Util/SSH2MP.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Util::SSH2MP;
 use strict;
+use warnings;
 
 use Math::Pari qw( PARI floor pari2num Mod lift );
 

--- a/lib/Net/SSH/Perl/Util/Term.pm
+++ b/lib/Net/SSH/Perl/Util/Term.pm
@@ -2,6 +2,7 @@
 
 package Net::SSH::Perl::Util::Term;
 use strict;
+use warnings;
 
 sub _prompt {
     my($prompt, $def, $echo) = @_;

--- a/lib/Net/SSH/Perl/Util/Win32.pm
+++ b/lib/Net/SSH/Perl/Util/Win32.pm
@@ -1,0 +1,59 @@
+package Net::SSH::Perl::Util::Win32;
+
+use strict;
+use warnings;
+
+use Socket ();
+use POSIX ();
+
+
+# Taken from AnyEvent::Util
+# Thanks, Mark!
+sub _socketpair() {
+    # perl's socketpair emulation fails on many vista machines, because
+    # vista returns fantasy port numbers.
+
+    for (1..10) {
+        socket my $l, Socket::AF_INET(), Socket::SOCK_STREAM(), 0
+            or next;
+
+        bind $l, Socket::pack_sockaddr_in 0, "\x7f\x00\x00\x01"
+            or next;
+
+        my $sa = getsockname $l
+            or next;
+
+        listen $l, 1
+            or next;
+
+        socket my $r, Socket::AF_INET(), Socket::SOCK_STREAM(), 0
+            or next;
+
+        bind $r, Socket::pack_sockaddr_in 0, "\x7f\x00\x00\x01"
+            or next;
+
+        connect $r, $sa
+            or next;
+
+        accept my $w, $l
+            or next;
+
+        # vista has completely broken peername/sockname that return
+        # fantasy ports. this combo seems to work, though.
+        (Socket::unpack_sockaddr_in getpeername $r)[0]
+            == (Socket::unpack_sockaddr_in getsockname $w)[0]
+               or (($! = POSIX::EWOULDBLOCK() && POSIX::EINVAL() ), next);
+
+        # vista example (you can't make this shit up...):
+        #(Socket::unpack_sockaddr_in getsockname $r)[0] == 53364
+        #(Socket::unpack_sockaddr_in getpeername $r)[0] == 53363
+        #(Socket::unpack_sockaddr_in getsockname $w)[0] == 53363
+        #(Socket::unpack_sockaddr_in getpeername $w)[0] == 53365
+
+        return ($r, $w);
+    }
+
+    ()
+}
+
+1;


### PR DESCRIPTION
The notes below are produced mostly for the commit https://github.com/renormalist/Net-SSH-Perl/commit/617e58d804aaa309c346a9176bcb7d11e0a26051

There is a problem with using select() on Windows platform. OS Windows has limitation for this call: it is working only for sockets. 

As I see the select() call is using on duped filehandles stdin, stdout, stderr in Net/SSH/Perl/SSH2.pm module. I've tried to get a workaround on it, but I suppose there is should be much more work on it.

At least eg\cmd.pl is working on my system now. Specs: Windows 7 64-bit; Strawberry Perl 5.22.0 32-bit (64-bit version does not contains required Math::Pari module).

Thanks.
